### PR TITLE
Keep file descriptors

### DIFF
--- a/lib/fluent/plugin/in_multiprocess.rb
+++ b/lib/fluent/plugin/in_multiprocess.rb
@@ -33,6 +33,7 @@ module Fluent
       config_param :cmdline, :string
       config_param :sleep_before_start, :time, :default => 0
       config_param :sleep_before_shutdown, :time, :default => 0
+      config_param :keep_file_descriptors, :bool, :default => false
 
       attr_accessor :process_monitor
     end
@@ -65,7 +66,8 @@ module Fluent
         cmd = "#{Shellwords.shellescape(RbConfig.ruby)} #{Shellwords.shellescape(fluentd_rb)} #{pe.cmdline}"
         sleep pe.sleep_before_start if pe.sleep_before_start > 0
         $log.info "launching child fluentd #{pe.cmdline}"
-        pe.process_monitor = @pm.spawn(cmd)
+        options = {:close_others => !pe.keep_file_descriptors}
+        pe.process_monitor = @pm.spawn(cmd, options)
       end
     end
 


### PR DESCRIPTION
Add `keep_file_descriptors` option. `Process#spawn` closes file descriptors, but I want to inherit file descriptors of the parent process. 

I added two patterns for the option. One is for global:

```apache
<source>
  type multiprocess
  keep_file_descriptors true
  <process>
    cmdline -c in_forward.conf
  </process>
  <process>
    cmdline -c in_forward.conf
  </process>
</source>
```

Another is for each process:

```apache
<source>
  type multiprocess
  keep_file_descriptors false
  <process>
    cmdline -c in_forward.conf
    keep_file_descriptors true # outcome the global
  </process>
  <process>
    cmdline -c in_forward.conf
    keep_file_descriptors true
  </process>
</source>
```

cf. http://blog.livedoor.jp/sonots/archives/43219930.html (Japanese)
